### PR TITLE
Relax dependency on a specific version of Mongoid, compatibility with Mongoid 4.x.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
-Version 0.2.0
-=============
+Next Release
+------------
+
+* Compatibility with Mongoid 4.x - [@dblock](https://github.com/dblock).
+
+0.2.0
+-----
 
 Important note for those upgrading from 0.1.0 (pre-Mongoid 3.0) to 0.2.0 (Mongoid 3.x): you'll need to upgrade any
 existing snapshots created by mongoid_collection_snapshot 0.1.0 in your database before they're usable. You can
@@ -12,7 +17,7 @@ to upgrade the snapshot class "MySnapshot", you'd enter the following at the mon
 * Added support for [Mongoid 3.0](https://github.com/mongoid/mongoid) - [@dblock](https://github.com/dblock).
 * Relaxed version limitations of [mongoid_slug](https://github.com/digitalplaywright/mongoid-slug) - [@dblock](https://github.com/dblock).
 
-Version 0.1.0
-=============
+0.1.0
+-----
 
 * Initial public release - [@aaw](https://github.com/aaw).

--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,9 @@
 source "http://rubygems.org"
 
-gem "mongoid", "~> 3.0"
+gem "mongoid", ">= 3.0"
 gem "mongoid_slug"
 
 group :development do
-  gem "mongoid", "~> 3.0"
   gem "rspec", "~> 2.11.0"
   gem "jeweler", "~> 1.8.4"
 end

--- a/Rakefile
+++ b/Rakefile
@@ -25,11 +25,11 @@ Jeweler::Tasks.new do |gem|
 end
 Jeweler::RubygemsDotOrgTasks.new
 
-require 'rake/testtask'
-Rake::TestTask.new(:test) do |test|
-  test.libs << 'lib' << 'test'
-  test.pattern = 'test/**/test_*.rb'
-  test.verbose = true
+require 'rspec/core'
+require 'rspec/core/rake_task'
+RSpec::Core::RakeTask.new(:spec) do |spec|
+  spec.pattern = FileList['spec/**/*_spec.rb']
+  spec.rspec_opts = "--color --format progress"
 end
 
-task :default => :test
+task :default => :spec

--- a/mongoid_collection_snapshot.gemspec
+++ b/mongoid_collection_snapshot.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Aaron Windsor"]
-  s.date = "2012-11-04"
+  s.date = "2013-10-21"
   s.description = "Easy maintenence of collections of processed data in MongoDB with the Mongoid ODM"
   s.email = "aaron.windsor@gmail.com"
   s.extra_rdoc_files = [
@@ -34,29 +34,26 @@ Gem::Specification.new do |s|
   s.homepage = "http://github.com/aaw/mongoid_collection_snapshot"
   s.licenses = ["MIT"]
   s.require_paths = ["lib"]
-  s.rubygems_version = "1.8.24"
+  s.rubygems_version = "1.8.25"
   s.summary = "Easy maintenence of collections of processed data in MongoDB with the Mongoid ODM"
 
   if s.respond_to? :specification_version then
     s.specification_version = 3
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<mongoid>, ["~> 3.0"])
+      s.add_runtime_dependency(%q<mongoid>, [">= 3.0"])
       s.add_runtime_dependency(%q<mongoid_slug>, [">= 0"])
-      s.add_development_dependency(%q<mongoid>, ["~> 3.0"])
       s.add_development_dependency(%q<rspec>, ["~> 2.11.0"])
       s.add_development_dependency(%q<jeweler>, ["~> 1.8.4"])
     else
-      s.add_dependency(%q<mongoid>, ["~> 3.0"])
+      s.add_dependency(%q<mongoid>, [">= 3.0"])
       s.add_dependency(%q<mongoid_slug>, [">= 0"])
-      s.add_dependency(%q<mongoid>, ["~> 3.0"])
       s.add_dependency(%q<rspec>, ["~> 2.11.0"])
       s.add_dependency(%q<jeweler>, ["~> 1.8.4"])
     end
   else
-    s.add_dependency(%q<mongoid>, ["~> 3.0"])
+    s.add_dependency(%q<mongoid>, [">= 3.0"])
     s.add_dependency(%q<mongoid_slug>, [">= 0"])
-    s.add_dependency(%q<mongoid>, ["~> 3.0"])
     s.add_dependency(%q<rspec>, ["~> 2.11.0"])
     s.add_dependency(%q<jeweler>, ["~> 1.8.4"])
   end

--- a/spec/mongoid/collection_snapshot_spec.rb
+++ b/spec/mongoid/collection_snapshot_spec.rb
@@ -4,7 +4,7 @@ module Mongoid
   describe CollectionSnapshot do
 
     context "creating a basic snapshot" do
-      
+
       let!(:flowers)     { Artwork.create(:name => 'Flowers', :artist => 'Andy Warhol', :price => 3000000) }
       let!(:guns)        { Artwork.create(:name => 'Guns', :artist => 'Andy Warhol', :price => 1000000) }
       let!(:vinblastine) { Artwork.create(:name => 'Vinblastine', :artist => 'Damien Hirst', :price => 1500000) }
@@ -31,7 +31,7 @@ module Mongoid
         AverageArtistPrice.latest.should == second
         sleep(1)
         third = AverageArtistPrice.create
-        AverageArtistPrice.latest.should == third        
+        AverageArtistPrice.latest.should == third
       end
 
       it "should only maintain at most two of the latest snapshots to support its calculations" do
@@ -45,7 +45,7 @@ module Mongoid
     end
 
     context "creating a snapshot containing multiple collections" do
-      
+
       it "populates several collections and allows them to be queried" do
         MultiCollectionSnapshot.latest.should be_nil
         10.times { MultiCollectionSnapshot.create }


### PR DESCRIPTION
This is a trivial gemspec change that makes this gem compatible with Mongoid 4. No code changes were necessary. Since that hasn't shipped you would need to do this in Gemfile to test:

``` ruby
gem "mongoid", ">= 3.0", github: "mongoid/mongoid"
gem "mongoid_slug", github: "dblock/mongoid-slug", branch: "mongoid-4x"
```
