### PR TITLE
Expose snapshot_session for custom snapshot storage.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Next Release
 ------------
 
+* Expose `snapshot_session` for custom snapshot storage - [@joeyAghion](https://github.com/joeyAghion)
 * Compatibility with Mongoid 4.x - [@dblock](https://github.com/dblock).
 
 0.2.0

--- a/spec/models/custom_connection_snapshot.rb
+++ b/spec/models/custom_connection_snapshot.rb
@@ -1,0 +1,18 @@
+class CustomConnectionSnapshot
+  include Mongoid::CollectionSnapshot
+
+  def self.snapshot_session
+    @@snapshot_session ||= Moped::Session.new(['127.0.0.1:27017']).tap do |session|
+      session.use :snapshot_test
+    end
+  end
+
+  def snapshot_session
+    self.class.snapshot_session
+  end
+
+  def build
+    collection_snapshot.insert('name' => 'foo')
+    collection_snapshot('foo').insert({'name' => 'bar'})
+  end
+end

--- a/spec/mongoid/collection_snapshot_spec.rb
+++ b/spec/mongoid/collection_snapshot_spec.rb
@@ -76,5 +76,26 @@ module Mongoid
 
     end
 
+    context "with a custom snapshot connection" do
+
+      around(:each) do |example|
+        CustomConnectionSnapshot.snapshot_session.drop
+        example.run
+        CustomConnectionSnapshot.snapshot_session.drop
+      end
+
+      it "builds snapshot in custom database" do
+        snapshot = CustomConnectionSnapshot.create
+        [
+          "#{CustomConnectionSnapshot.collection.name}.foo.#{snapshot.slug}",
+          "#{CustomConnectionSnapshot.collection.name}.#{snapshot.slug}"
+        ].each do |collection_name|
+          Mongoid.default_session[collection_name].find.count.should == 0
+          CustomConnectionSnapshot.snapshot_session[collection_name].find.count.should == 1
+        end
+      end
+
+    end
+
   end
 end


### PR DESCRIPTION
This is code from @joeyAghion, we now store snapshot data in a separate database. In this PR we expose `snapshot_session` that lets you choose which session (database) to read from.
