### PR TITLE
Added support for accessing snapshot collection documents via Mongoid::CollectionSnapshot#documents.

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,2 @@
+--color
+--format=progress

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,5 @@ env:
 language: ruby
 
 cache: bundler
+
+sudo: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Next Release
 ------------
 
+* Upgraded RSpec - [@dblock](https://github.com/dblock).
+* Your contribution here.
+
 1.0.1
 -----
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 Next Release
 ------------
 
-* Upgraded RSpec - [@dblock](https://github.com/dblock).
+* [#10](https://github.com/aaw/mongoid_collection_snapshot/pull/10): Added support for accessing snapshot collection documents via Mongoid::CollectionSnapshot#documents - [@dblock](https://github.com/dblock).
+* [#9](https://github.com/aaw/mongoid_collection_snapshot/pull/9): Upgraded RSpec - [@dblock](https://github.com/dblock).
 * Your contribution here.
 
 1.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 Next Release
 ------------
 
-* [#10](https://github.com/aaw/mongoid_collection_snapshot/pull/10): Added support for accessing snapshot collection documents via Mongoid::CollectionSnapshot#documents - [@dblock](https://github.com/dblock).
-* [#9](https://github.com/aaw/mongoid_collection_snapshot/pull/9): Upgraded RSpec - [@dblock](https://github.com/dblock).
+* [#11](https://github.com/aaw/mongoid_collection_snapshot/pull/10): Added support for accessing snapshot collection documents via Mongoid::CollectionSnapshot#documents - [@dblock](https://github.com/dblock).
+* [#11](https://github.com/aaw/mongoid_collection_snapshot/pull/11): Upgraded RSpec - [@dblock](https://github.com/dblock).
 * Your contribution here.
 
 1.0.1

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source "http://rubygems.org"
+source 'http://rubygems.org'
 
 case version = ENV['MONGOID_VERSION'] || '~> 4.0'
 when /4/
@@ -9,10 +9,9 @@ else
   gem 'mongoid', version
 end
 
-gem "mongoid_slug"
+gem 'mongoid_slug'
 
 group :development, :test do
-  gem "rspec", "~> 3.1"
-  gem "rake"
+  gem 'rspec', '~> 3.1'
+  gem 'rake'
 end
-

--- a/Gemfile
+++ b/Gemfile
@@ -14,4 +14,5 @@ gem 'mongoid_slug'
 group :development, :test do
   gem 'rspec', '~> 3.1'
   gem 'rake'
+  gem 'timecop'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ end
 gem "mongoid_slug"
 
 group :development, :test do
-  gem "rspec", "~> 2.11.0"
+  gem "rspec", "~> 3.1"
   gem "rake"
 end
 

--- a/README.md
+++ b/README.md
@@ -8,30 +8,18 @@ Easy maintenance of collections of processed data in MongoDB with the Mongoid 3.
 Quick example:
 --------------
 
-Suppose that you have a Mongoid model called `Artwork`, stored
-in a MongoDB collection called `artworks` and the underlying documents
-look something like:
+Suppose that you have a Mongoid model called `Artwork`, stored in a MongoDB collection called `artworks` and the underlying documents look something like:
 
     { name: 'Flowers', artist: 'Andy Warhol', price: 3000000 }
 
-From time to time, your system runs a map/reduce job to compute the
-average price of each artist's works, resulting in a collection called
-`artist_average_price` that contains documents that look like:
+From time to time, your system runs a map/reduce job to compute the average price of each artist's works, resulting in a collection called `artist_average_price` that contains documents that look like:
 
-    { _id: { artist: 'Andy Warhol'}, value: { price: 1500000 } }
+    { _id: { artist: 'Andy Warhol' }, value: { price: 1500000 } }
 
-If your system wants to maintain and use this average price data, it has
-to do so at the level of raw MongoDB operations, since
-map/reduce result documents don't map well to models in Mongoid.
-Furthermore, even though map/reduce jobs can take some time to run, you probably
-want the entire `artist_average_price` collection populated atomically
-from the point of view of your system, since otherwise you don't ever
-know the state of the data in the collection - you could access it in
-the middle of a map/reduce and get partial, incorrect results.
+If your system wants to maintain and use this average price data, it has to do so at the level of raw MongoDB operations, since map/reduce result documents don't map well to models in Mongoid.
+Furthermore, even though map/reduce jobs can take some time to run, you probably want the entire `artist_average_price` collection populated atomically from the point of view of your system, since otherwise you don't ever know the state of the data in the collection - you could access it in the middle of a map/reduce and get partial, incorrect results.
 
-mongoid_collection_snapshot solves this problem by providing an atomic
-view of collections of data like map/reduce results that live outside
-of Mongoid.
+A mongoid_collection_snapshot solves this problem by providing an atomic view of collections of data like map/reduce results that live outside of Mongoid.
 
 In the example above, we'd set up our average artist price collection like:
 
@@ -40,9 +28,10 @@ class AverageArtistPrice
   include Mongoid::CollectionSnapshot
 
   def build
+
     map = <<-EOS
       function() {
-        emit({artist: this['artist']}, {count: 1, sum: this['price']})
+        emit({ artist_id: this['artist_id']}, { count: 1, sum: this['price'] })
       }
     EOS
 
@@ -51,49 +40,82 @@ class AverageArtistPrice
         var sum = 0;
         var count = 0;
         values.forEach(function(value) {
-          sum += value['price'];
+          sum += value['sum'];
           count += value['count'];
         });
-        return({count: count, sum: sum});
+        return({ count: count, sum: sum });
       }
     EOS
 
-    Mongoid.default_session.command(
-      "mapreduce" => "artworks",
-      map: map,
-      reduce: reduce,
-      out: collection_snapshot.name)
+    Artwork.map_reduce(map, reduce).out(inline: 1).each do |doc|
+      collection_snapshot.insert(
+        artist_id: doc['_id']['artist_id'],
+        count: doc['value']['count'],
+        sum: doc['value']['sum']
+      )
+    end
   end
+end
 
-  def average_price(artist)
-    doc = collection_snapshot.find({'_id.artist': artist}).first
-    doc['value']['sum']/doc['value']['count']
+```
+
+Now, if you want to schedule a recomputation, just call `AverageArtistPrice.create`. You can define other methods on collection snapshots.
+
+```ruby
+class AverageArtistPrice
+  ...
+
+  def average_price(artist_name)
+    artist = Artist.where(name: artist_name).first
+    doc = collection_snapshot.where(artist_id: artist.id).first
+    doc['sum'] / doc['count']
   end
 end
 ```
 
-Now, if you want
-to schedule a recomputation, just call `AverageArtistPrice.create`. The latest
-snapshot is always available as `AverageArtistPrice.latest`, so you can write
-code like:
+The latest snapshot is always available as `AverageArtistPrice.latest`, so you can write code like:
 
-``` ruby
+```ruby
 warhol_expected_price = AverageArtistPrice.latest.average_price('Andy Warhol')
 ```
 
-And always be sure that you'll never be looking at partial results. The only
-thing you need to do to hook into mongoid_collection_snapshot is implement the
-method `build`, which populates the collection snapshot and any indexes you need.
+And always be sure that you'll never be looking at partial results. The only thing you need to do to hook into mongoid_collection_snapshot is implement the method `build`, which populates the collection snapshot and any indexes you need.
 
-By default, mongoid_collection_snapshot maintains the most recent two snapshots
-computed any given time.
+By default, mongoid_collection_snapshot maintains the most recent two snapshots computed any given time.
+
+Query Snapshot Data with Mongoid
+--------------------------------
+
+You can do better than the average price example above and define first-class models for your collection snapshot data, then access them as any other Mongoid collection via collection snapshot's `.documents` method.
+
+```ruby
+class AverageArtistPrice
+  document do
+    belongs_to :artist, inverse_of: nil
+    field :sum, type: Integer
+    field :count, type: Integer
+  end
+
+  def average_price(artist_name)
+    artist = Artist.where(name: artist_name).first
+    doc = documents.where(artist: artist).first
+    doc.sum / doc.count
+  end
+end
+```
+
+Another example iterates through all latest artist price averages.
+
+```ruby
+AverageArtistPrice.latest.documents.each do |doc|
+  puts "#{doc.artist.name}: #{doc.sum / doc.count}"
+end
+```
 
 Multi-collection snapshots
 --------------------------
 
-You can maintain multiple collections atomically within the same snapshot by
-passing unique collection identifiers to ``collection_snaphot`` when you call it
-in your build or query methods:
+You can maintain multiple collections atomically within the same snapshot by passing unique collection identifiers to `collection_snaphot` when you call it in your build or query methods:
 
 ``` ruby
 class ArtistStats
@@ -103,18 +125,49 @@ class ArtistStats
     # ...
     # define map/reduce for average and max aggregations
     # ...
-    Mongoid.default_session.command("mapreduce" => "artworks", map: map_avg, reduce: reduce_avg, out: collection_snapshot('average'))
-    Mongoid.default_session.command("mapreduce" => "artworks", map: map_max, reduce: reduce_max, out: collection_snapshot('max'))
+    Mongoid.default_session.command('mapreduce' => 'artworks', map: map_avg, reduce: reduce_avg, out: collection_snapshot('average'))
+    Mongoid.default_session.command('mapreduce' => 'artworks', map: map_max, reduce: reduce_max, out: collection_snapshot('max'))
   end
 
   def average_price(artist)
-    doc = collection_snapshot('average').find({'_id.artist': artist}).first
-    doc['value']['sum']/doc['value']['count']
+    doc = collection_snapshot('average').find('_id.artist' => artist).first
+    doc['value']['sum'] / doc['value']['count']
   end
 
   def max_price(artist)
-    doc = collection_snapshot('max').find({'_id.artist': artist}).first
+    doc = collection_snapshot('max').find('_id.artist' => artist).first
     doc['value']['max']
+  end
+end
+```
+
+Specify the name of the collection to define first class Mongoid models.
+
+```ruby
+class ArtistStats
+  document('average') do
+    field :value, type: Hash
+  end
+
+  document('max') do
+    field :value, type: Hash
+  end
+end
+```
+
+Access these by name.
+
+```ruby
+ArtistStats.latest.documents('average')
+ArtistStats.latest.documents('max')
+```
+
+If fields across multiple collection snapshots are identical, a single default `document` is sufficient.
+
+```ruby
+class ArtistStats
+  document do
+    field :value, type: Hash
   end
 end
 ```

--- a/Rakefile
+++ b/Rakefile
@@ -9,7 +9,7 @@ begin
   Bundler.setup(:default, :development)
 rescue Bundler::BundlerError => e
   $stderr.puts e.message
-  $stderr.puts "Run `bundle install` to install missing gems"
+  $stderr.puts 'Run `bundle install` to install missing gems'
   exit e.status_code
 end
 
@@ -19,7 +19,7 @@ require 'rspec/core'
 require 'rspec/core/rake_task'
 RSpec::Core::RakeTask.new(:spec) do |spec|
   spec.pattern = FileList['spec/**/*_spec.rb']
-  spec.rspec_opts = "--color --format progress"
+  spec.rspec_opts = '--color --format progress'
 end
 
-task :default => :spec
+task default: :spec

--- a/lib/mongoid_collection_snapshot.rb
+++ b/lib/mongoid_collection_snapshot.rb
@@ -33,12 +33,13 @@ module Mongoid
         self.document_classes[key] ||= begin
           document_block = document_blocks[name || DEFAULT_COLLECTION_KEY_NAME] if document_blocks
           collection_name = collection_snapshot(name).name
-          collection_database = snapshot_session.options[:database]
           klass = Class.new do
             include Mongoid::Document
+            cattr_accessor :mongo_session
             instance_eval(&document_block) if document_block
-            store_in collection: collection_name, database: collection_database
+            store_in collection: collection_name
           end
+          klass.mongo_session = snapshot_session
           Object.const_set(class_name, klass)
           klass
         end

--- a/lib/mongoid_collection_snapshot.rb
+++ b/lib/mongoid_collection_snapshot.rb
@@ -28,8 +28,8 @@ module Mongoid
       # Mongoid documents on this snapshot.
       def documents(name = nil)
         self.document_classes ||= {}
-        class_name = "#{self.class.name}_#{slug}_#{name}".underscore.camelize
-        key = "#{class_name}_#{name || DEFAULT_COLLECTION_KEY_NAME}"
+        class_name = "#{self.class.name}#{id}#{name}".underscore.camelize
+        key = "#{class_name}-#{name || DEFAULT_COLLECTION_KEY_NAME}"
         self.document_classes[key] ||= begin
           document_block = document_blocks[name || DEFAULT_COLLECTION_KEY_NAME] if document_blocks
           collection_name = collection_snapshot(name).name

--- a/lib/mongoid_collection_snapshot.rb
+++ b/lib/mongoid_collection_snapshot.rb
@@ -1,59 +1,59 @@
 require 'mongoid_collection_snapshot/version'
 
-module Mongoid::CollectionSnapshot
-  extend ActiveSupport::Concern
+module Mongoid
+  module CollectionSnapshot
+    extend ActiveSupport::Concern
 
-  included do
-    require 'mongoid_slug'
+    included do
+      require 'mongoid_slug'
 
-    include Mongoid::Document
-    include Mongoid::Timestamps::Created
-    include Mongoid::Slug
+      include Mongoid::Document
+      include Mongoid::Timestamps::Created
+      include Mongoid::Slug
 
-    field :workspace_basename, default: 'snapshot'
-    slug :workspace_basename
+      field :workspace_basename, default: 'snapshot'
+      slug :workspace_basename
 
-    field :max_collection_snapshot_instances, default: 2
+      field :max_collection_snapshot_instances, default: 2
 
-    before_create :build
-    after_create :ensure_at_most_two_instances_exist
-    before_destroy :drop_snapshot_collections
-  end
+      before_create :build
+      after_create :ensure_at_most_two_instances_exist
+      before_destroy :drop_snapshot_collections
+    end
 
-  module ClassMethods
-    def latest
-      order_by([[:created_at, :desc]]).first
+    module ClassMethods
+      def latest
+        order_by([[:created_at, :desc]]).first
+      end
+    end
+
+    def collection_snapshot(name = nil)
+      if name
+        snapshot_session["#{collection.name}.#{name}.#{slug}"]
+      else
+        snapshot_session["#{collection.name}.#{slug}"]
+      end
+    end
+
+    def drop_snapshot_collections
+      snapshot_session.collections.each do |collection|
+        collection.drop if collection.name =~ /^#{self.collection.name}\.([^\.]+\.)?#{slug}$/
+      end
+    end
+
+    # Since we should always be using the latest instance of this class, this method is
+    # called after each save - making sure only at most two instances exists should be
+    # sufficient to ensure that this data can be rebuilt live without corrupting any
+    # existing computations that might have a handle to the previous "latest" instance.
+    def ensure_at_most_two_instances_exist
+      all_instances = self.class.order_by([[:created_at, :desc]]).to_a
+      return unless all_instances.length > max_collection_snapshot_instances
+      all_instances[max_collection_snapshot_instances..-1].each(&:destroy)
+    end
+
+    # Override to supply custom database connection for snapshots
+    def snapshot_session
+      Mongoid.default_session
     end
   end
-
-  def collection_snapshot(name=nil)
-    if name
-      snapshot_session["#{self.collection.name}.#{name}.#{slug}"]
-    else
-      snapshot_session["#{self.collection.name}.#{slug}"]
-    end
-  end
-
-  def drop_snapshot_collections
-    snapshot_session.collections.each do |collection|
-      collection.drop if collection.name =~ /^#{self.collection.name}\.([^\.]+\.)?#{slug}$/
-    end
-  end
-
-  # Since we should always be using the latest instance of this class, this method is
-  # called after each save - making sure only at most two instances exists should be
-  # sufficient to ensure that this data can be rebuilt live without corrupting any
-  # existing computations that might have a handle to the previous "latest" instance.
-  def ensure_at_most_two_instances_exist
-    all_instances = self.class.order_by([[:created_at, :desc]]).to_a
-    if all_instances.length > self.max_collection_snapshot_instances
-      all_instances[self.max_collection_snapshot_instances..-1].each { |instance| instance.destroy }
-    end
-  end
-
-  # Override to supply custom database connection for snapshots
-  def snapshot_session
-    Mongoid.default_session
-  end
-
 end

--- a/lib/mongoid_collection_snapshot/version.rb
+++ b/lib/mongoid_collection_snapshot/version.rb
@@ -3,5 +3,3 @@ module Mongoid
     VERSION = '1.0.1'
   end
 end
-
-

--- a/spec/models/artist.rb
+++ b/spec/models/artist.rb
@@ -1,0 +1,7 @@
+class Artist
+  include Mongoid::Document
+
+  field :name
+
+  has_many :artworks
+end

--- a/spec/models/artwork.rb
+++ b/spec/models/artwork.rb
@@ -2,6 +2,7 @@ class Artwork
   include Mongoid::Document
 
   field :name
-  field :artist
   field :price
+
+  belongs_to :artist
 end

--- a/spec/models/average_artist_price.rb
+++ b/spec/models/average_artist_price.rb
@@ -21,15 +21,14 @@ class AverageArtistPrice
     EOS
 
     Mongoid.default_session.command(
-      "mapreduce" => "artworks",
+      'mapreduce' => 'artworks',
       map: map,
       reduce: reduce,
       out: collection_snapshot.name)
   end
 
   def average_price(artist)
-    doc = collection_snapshot.where({'_id.artist' => artist}).first
-    doc['value']['sum']/doc['value']['count']
+    doc = collection_snapshot.where('_id.artist' => artist).first
+    doc['value']['sum'] / doc['value']['count']
   end
-
 end

--- a/spec/models/custom_connection_snapshot.rb
+++ b/spec/models/custom_connection_snapshot.rb
@@ -2,7 +2,7 @@ class CustomConnectionSnapshot
   include Mongoid::CollectionSnapshot
 
   def self.snapshot_session
-    @@snapshot_session ||= Moped::Session.new(['127.0.0.1:27017']).tap do |session|
+    @snapshot_session ||= Moped::Session.new(['127.0.0.1:27017']).tap do |session|
       session.use :snapshot_test
     end
   end
@@ -13,6 +13,6 @@ class CustomConnectionSnapshot
 
   def build
     collection_snapshot.insert('name' => 'foo')
-    collection_snapshot('foo').insert({'name' => 'bar'})
+    collection_snapshot('foo').insert('name' => 'bar')
   end
 end

--- a/spec/models/multi_collection_snapshot.rb
+++ b/spec/models/multi_collection_snapshot.rb
@@ -1,14 +1,13 @@
 class MultiCollectionSnapshot
   include Mongoid::CollectionSnapshot
-  
+
   def build
-    collection_snapshot('foo').insert({'name' => 'foo!'})
-    collection_snapshot('bar').insert({'name' => 'bar!'})
-    collection_snapshot('baz').insert({'name' => 'baz!'})
+    collection_snapshot('foo').insert('name' => 'foo!')
+    collection_snapshot('bar').insert('name' => 'bar!')
+    collection_snapshot('baz').insert('name' => 'baz!')
   end
 
-  def get_names
-    ['foo', 'bar', 'baz'].map{ |x| collection_snapshot(x).find.first['name'] }.join('')
+  def names
+    %w(foo bar baz).map { |x| collection_snapshot(x).find.first['name'] }.join('')
   end
-
 end

--- a/spec/models/multi_collection_snapshot.rb
+++ b/spec/models/multi_collection_snapshot.rb
@@ -1,10 +1,25 @@
 class MultiCollectionSnapshot
   include Mongoid::CollectionSnapshot
 
+  document('foo') do
+    field :name, type: String
+    field :count, type: Integer
+  end
+
+  document('bar') do
+    field :name, type: String
+    field :number, type: Integer
+  end
+
+  document('baz') do
+    field :name, type: String
+    field :digit, type: Integer
+  end
+
   def build
-    collection_snapshot('foo').insert('name' => 'foo!')
-    collection_snapshot('bar').insert('name' => 'bar!')
-    collection_snapshot('baz').insert('name' => 'baz!')
+    collection_snapshot('foo').insert('name' => 'foo!', count: 1)
+    collection_snapshot('bar').insert('name' => 'bar!', number: 2)
+    collection_snapshot('baz').insert('name' => 'baz!', digit: 3)
   end
 
   def names

--- a/spec/mongoid/collection_snapshot_spec.rb
+++ b/spec/mongoid/collection_snapshot_spec.rb
@@ -4,7 +4,7 @@ module Mongoid
   describe CollectionSnapshot do
 
     it "has a version" do
-      Mongoid::CollectionSnapshot::VERSION.should_not be_nil
+      expect(Mongoid::CollectionSnapshot::VERSION).not_to be_nil
     end
 
     context "creating a basic snapshot" do
@@ -14,35 +14,35 @@ module Mongoid
       let!(:vinblastine) { Artwork.create(:name => 'Vinblastine', :artist => 'Damien Hirst', :price => 1500000) }
 
       it "returns nil if no snapshot has been created" do
-        AverageArtistPrice.latest.should be_nil
+        expect(AverageArtistPrice.latest).to be_nil
       end
 
       it "runs the build method on creation" do
         snapshot = AverageArtistPrice.create
-        snapshot.average_price('Andy Warhol').should == 2000000
-        snapshot.average_price('Damien Hirst').should == 1500000
+        expect(snapshot.average_price('Andy Warhol')).to eq(2000000)
+        expect(snapshot.average_price('Damien Hirst')).to eq(1500000)
       end
 
       it "returns the most recent snapshot through the latest methods" do
         first = AverageArtistPrice.create
-        first.should == AverageArtistPrice.latest
+        expect(first).to eq(AverageArtistPrice.latest)
         # "latest" only works up to a resolution of 1 second since it relies on Mongoid::Timestamp. But this
         # module is meant to snapshot long-running collection creation, so if you need a resolution of less
         # than a second for "latest" then you're probably using the wrong gem. In tests, sleeping for a second
         # makes sure we get what we expect.
         sleep(1)
         second = AverageArtistPrice.create
-        AverageArtistPrice.latest.should == second
+        expect(AverageArtistPrice.latest).to eq(second)
         sleep(1)
         third = AverageArtistPrice.create
-        AverageArtistPrice.latest.should == third
+        expect(AverageArtistPrice.latest).to eq(third)
       end
 
       it "should only maintain at most two of the latest snapshots to support its calculations" do
         AverageArtistPrice.create
         10.times do
           AverageArtistPrice.create
-          AverageArtistPrice.count.should == 2
+          expect(AverageArtistPrice.count).to eq(2)
         end
       end
 
@@ -51,9 +51,9 @@ module Mongoid
     context "creating a snapshot containing multiple collections" do
 
       it "populates several collections and allows them to be queried" do
-        MultiCollectionSnapshot.latest.should be_nil
+        expect(MultiCollectionSnapshot.latest).to be_nil
         10.times { MultiCollectionSnapshot.create }
-        MultiCollectionSnapshot.latest.get_names.should == "foo!bar!baz!"
+        expect(MultiCollectionSnapshot.latest.get_names).to eq("foo!bar!baz!")
       end
 
       it "safely cleans up all collections used by the snapshot" do
@@ -64,18 +64,18 @@ module Mongoid
 
         MultiCollectionSnapshot.create
         before_create = Mongoid.default_session.collections.map{ |c| c.name }
-        before_create.length.should > 0
+        expect(before_create.length).to be > 0
 
         sleep(1)
         MultiCollectionSnapshot.create
         after_create = Mongoid.default_session.collections.map{ |c| c.name }
         collections_created = (after_create - before_create).sort
-        collections_created.length.should == 3
+        expect(collections_created.length).to eq(3)
 
         MultiCollectionSnapshot.latest.destroy
         after_destroy = Mongoid.default_session.collections.map{ |c| c.name }
         collections_destroyed = (after_create - after_destroy).sort
-        collections_created.should == collections_destroyed
+        expect(collections_created).to eq(collections_destroyed)
       end
 
     end
@@ -94,8 +94,8 @@ module Mongoid
           "#{CustomConnectionSnapshot.collection.name}.foo.#{snapshot.slug}",
           "#{CustomConnectionSnapshot.collection.name}.#{snapshot.slug}"
         ].each do |collection_name|
-          Mongoid.default_session[collection_name].find.count.should == 0
-          CustomConnectionSnapshot.snapshot_session[collection_name].find.count.should == 1
+          expect(Mongoid.default_session[collection_name].find.count).to eq(0)
+          expect(CustomConnectionSnapshot.snapshot_session[collection_name].find.count).to eq(1)
         end
       end
 

--- a/spec/mongoid/collection_snapshot_spec.rb
+++ b/spec/mongoid/collection_snapshot_spec.rb
@@ -28,10 +28,10 @@ module Mongoid
         # module is meant to snapshot long-running collection creation, so if you need a resolution of less
         # than a second for "latest" then you're probably using the wrong gem. In tests, sleeping for a second
         # makes sure we get what we expect.
-        sleep(1)
+        Timecop.travel(1.second.from_now)
         second = AverageArtistPrice.create
         expect(AverageArtistPrice.latest).to eq(second)
-        sleep(1)
+        Timecop.travel(1.second.from_now)
         third = AverageArtistPrice.create
         expect(AverageArtistPrice.latest).to eq(third)
       end
@@ -62,7 +62,7 @@ module Mongoid
         before_create = Mongoid.default_session.collections.map(&:name)
         expect(before_create.length).to be > 0
 
-        sleep(1)
+        Timecop.travel(1.second.from_now)
         MultiCollectionSnapshot.create
         after_create = Mongoid.default_session.collections.map(&:name)
         collections_created = (after_create - before_create).sort

--- a/spec/mongoid/collection_snapshot_spec.rb
+++ b/spec/mongoid/collection_snapshot_spec.rb
@@ -55,6 +55,14 @@ module Mongoid
           expect(document.count).to eq 2
           expect(document.sum).to eq 4_000_000
         end
+
+        it 'only creates one global class reference' do
+          2.times do
+            index = AverageArtistPrice.create
+            2.times { expect(index.documents.count).to eq 2 }
+          end
+          expect(AverageArtistPrice.document_classes.count).to eq 2
+        end
       end
     end
 

--- a/spec/mongoid/collection_snapshot_spec.rb
+++ b/spec/mongoid/collection_snapshot_spec.rb
@@ -115,6 +115,9 @@ module Mongoid
       end
 
       context '#documents' do
+        it 'uses the custom session' do
+          expect(CustomConnectionSnapshot.new.documents.mongo_session).to eq CustomConnectionSnapshot.snapshot_session
+        end
         it 'provides access to a Mongoid collection' do
           snapshot = CustomConnectionSnapshot.create
           expect(snapshot.collection_snapshot.find.count).to eq 1

--- a/spec/mongoid/collection_snapshot_spec.rb
+++ b/spec/mongoid/collection_snapshot_spec.rb
@@ -57,11 +57,11 @@ module Mongoid
         end
 
         it 'only creates one global class reference' do
-          2.times do
+          3.times do
             index = AverageArtistPrice.create
             2.times { expect(index.documents.count).to eq 2 }
           end
-          expect(AverageArtistPrice.document_classes.count).to eq 2
+          expect(AverageArtistPrice.document_classes.count).to be >= 3
         end
       end
     end

--- a/spec/mongoid/collection_snapshot_spec.rb
+++ b/spec/mongoid/collection_snapshot_spec.rb
@@ -2,28 +2,26 @@ require 'spec_helper'
 
 module Mongoid
   describe CollectionSnapshot do
-
-    it "has a version" do
+    it 'has a version' do
       expect(Mongoid::CollectionSnapshot::VERSION).not_to be_nil
     end
 
-    context "creating a basic snapshot" do
+    context 'creating a basic snapshot' do
+      let!(:flowers)     { Artwork.create(name: 'Flowers', artist: 'Andy Warhol', price: 3_000_000) }
+      let!(:guns)        { Artwork.create(name: 'Guns', artist: 'Andy Warhol', price: 1_000_000) }
+      let!(:vinblastine) { Artwork.create(name: 'Vinblastine', artist: 'Damien Hirst', price: 1_500_000) }
 
-      let!(:flowers)     { Artwork.create(:name => 'Flowers', :artist => 'Andy Warhol', :price => 3000000) }
-      let!(:guns)        { Artwork.create(:name => 'Guns', :artist => 'Andy Warhol', :price => 1000000) }
-      let!(:vinblastine) { Artwork.create(:name => 'Vinblastine', :artist => 'Damien Hirst', :price => 1500000) }
-
-      it "returns nil if no snapshot has been created" do
+      it 'returns nil if no snapshot has been created' do
         expect(AverageArtistPrice.latest).to be_nil
       end
 
-      it "runs the build method on creation" do
+      it 'runs the build method on creation' do
         snapshot = AverageArtistPrice.create
-        expect(snapshot.average_price('Andy Warhol')).to eq(2000000)
-        expect(snapshot.average_price('Damien Hirst')).to eq(1500000)
+        expect(snapshot.average_price('Andy Warhol')).to eq(2_000_000)
+        expect(snapshot.average_price('Damien Hirst')).to eq(1_500_000)
       end
 
-      it "returns the most recent snapshot through the latest methods" do
+      it 'returns the most recent snapshot through the latest methods' do
         first = AverageArtistPrice.create
         expect(first).to eq(AverageArtistPrice.latest)
         # "latest" only works up to a resolution of 1 second since it relies on Mongoid::Timestamp. But this
@@ -38,57 +36,53 @@ module Mongoid
         expect(AverageArtistPrice.latest).to eq(third)
       end
 
-      it "should only maintain at most two of the latest snapshots to support its calculations" do
+      it 'should only maintain at most two of the latest snapshots to support its calculations' do
         AverageArtistPrice.create
         10.times do
           AverageArtistPrice.create
           expect(AverageArtistPrice.count).to eq(2)
         end
       end
-
     end
 
-    context "creating a snapshot containing multiple collections" do
-
-      it "populates several collections and allows them to be queried" do
+    context 'creating a snapshot containing multiple collections' do
+      it 'populates several collections and allows them to be queried' do
         expect(MultiCollectionSnapshot.latest).to be_nil
         10.times { MultiCollectionSnapshot.create }
-        expect(MultiCollectionSnapshot.latest.get_names).to eq("foo!bar!baz!")
+        expect(MultiCollectionSnapshot.latest.names).to eq('foo!bar!baz!')
       end
 
-      it "safely cleans up all collections used by the snapshot" do
+      it 'safely cleans up all collections used by the snapshot' do
         # Create some collections with names close to the snapshots we'll create
-        Mongoid.default_session["#{MultiCollectionSnapshot.collection.name}.do.not_delete"].insert({'a' => 1})
-        Mongoid.default_session["#{MultiCollectionSnapshot.collection.name}.snapshorty"].insert({'a' => 1})
-        Mongoid.default_session["#{MultiCollectionSnapshot.collection.name}.hello.1"].insert({'a' => 1})
+        Mongoid.default_session["#{MultiCollectionSnapshot.collection.name}.do.not_delete"].insert('a' => 1)
+        Mongoid.default_session["#{MultiCollectionSnapshot.collection.name}.snapshorty"].insert('a' => 1)
+        Mongoid.default_session["#{MultiCollectionSnapshot.collection.name}.hello.1"].insert('a' => 1)
 
         MultiCollectionSnapshot.create
-        before_create = Mongoid.default_session.collections.map{ |c| c.name }
+        before_create = Mongoid.default_session.collections.map(&:name)
         expect(before_create.length).to be > 0
 
         sleep(1)
         MultiCollectionSnapshot.create
-        after_create = Mongoid.default_session.collections.map{ |c| c.name }
+        after_create = Mongoid.default_session.collections.map(&:name)
         collections_created = (after_create - before_create).sort
         expect(collections_created.length).to eq(3)
 
         MultiCollectionSnapshot.latest.destroy
-        after_destroy = Mongoid.default_session.collections.map{ |c| c.name }
+        after_destroy = Mongoid.default_session.collections.map(&:name)
         collections_destroyed = (after_create - after_destroy).sort
         expect(collections_created).to eq(collections_destroyed)
       end
-
     end
 
-    context "with a custom snapshot connection" do
-
+    context 'with a custom snapshot connection' do
       around(:each) do |example|
         CustomConnectionSnapshot.snapshot_session.drop
         example.run
         CustomConnectionSnapshot.snapshot_session.drop
       end
 
-      it "builds snapshot in custom database" do
+      it 'builds snapshot in custom database' do
         snapshot = CustomConnectionSnapshot.create
         [
           "#{CustomConnectionSnapshot.collection.name}.foo.#{snapshot.slug}",
@@ -98,8 +92,6 @@ module Mongoid
           expect(CustomConnectionSnapshot.snapshot_session[collection_name].find.count).to eq(1)
         end
       end
-
     end
-
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,3 +20,6 @@ RSpec.configure do |c|
   end
 end
 
+RSpec.configure do |config|
+  config.raise_errors_for_deprecations!
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@ require 'bundler/setup'
 require 'rspec'
 
 require 'mongoid'
+require 'timecop'
 
 Mongoid.configure do |config|
   config.connect_to('mongoid_collection_snapshot_test')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,10 +5,10 @@ require 'rspec'
 require 'mongoid'
 
 Mongoid.configure do |config|
-  config.connect_to("mongoid_collection_snapshot_test")
+  config.connect_to('mongoid_collection_snapshot_test')
 end
 
-require File.expand_path("../../lib/mongoid_collection_snapshot", __FILE__)
+require File.expand_path('../../lib/mongoid_collection_snapshot', __FILE__)
 Dir["#{File.dirname(__FILE__)}/models/**/*.rb"].each { |f| require f }
 
 RSpec.configure do |c|
@@ -20,6 +20,4 @@ RSpec.configure do |c|
   end
 end
 
-RSpec.configure do |config|
-  config.raise_errors_for_deprecations!
-end
+RSpec.configure(&:raise_errors_for_deprecations!)


### PR DESCRIPTION
Same as #10 cherry-picked without Rubocop.

Ideally we'd like to query collection snapshots as any other, first-class, Mongoid collection. This enables that via a new `document` keyword that takes a block that will be used to derive a dynamic class connected to the snapshot collection.

```ruby
class AverageArtistPrice
  document do
    belongs_to :artist, inverse_of: nil
    field :sum, type: Integer
    field :count, type: Integer
  end
end
```

You can now do:

```ruby
andy_warhol = Artist.where(name: 'Andy Warhol').first
doc = AverageArtistPrice.latest.documents.where(artist: andy_warhol).first
average_price = doc.sum / doc.count
```

This is pretty awesome, since we can just use snapshot data as any other data in MongoDB via Mongoid and not via Moped.

All existing features, custom sessions and multi snapshots are supported.

This is on top of some bookkeeping done in #9.